### PR TITLE
Comment for agent deploy and management

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -2746,8 +2746,13 @@ echo '</ul>
       
     case "deploy":
       // manage registration vouchers
-      echo "Provide agent with valid voucher and this link:<br>";
-      echo "<a href=\"server.php?a=update\">Download agent</a><br><br>";
+      if (file_exists($exename)) {
+        echo "Provide agent with valid voucher and this link:<br>";
+        echo "<a href=\"server.php?a=update\">Download agent</a><br><br>";
+      } else {
+        echo "<p style='color:red'>There is no client executable file <b>$exename</b> in server root!<br>";
+        echo "Please upload $exename in order to deploy it to agents</p>";
+      }
       if (isset($_POST["newvoucher"])) {
         mysqli_query_wrapper($dblink,"INSERT INTO regvouchers (voucher,comment,time) VALUES ('".mysqli_real_escape_string($dblink,$_POST["newvoucher"])."','".mysqli_real_escape_string($dblink,$_POST["comment"])."',$cas)");
       }

--- a/admin.php
+++ b/admin.php
@@ -491,6 +491,16 @@ echo '</ul>
       }
       break;
       
+    case "agentcomment";
+      // change agent comment
+      $agid=intval($_POST["agent"]);
+      $pars=mysqli_real_escape_string($dblink,$_POST["comment"]);
+      $vysledek=mysqli_query_wrapper($dblink,"UPDATE agents SET comment='$pars' WHERE id=$agid");
+      if (!$vysledek) {
+        echo "<script>alert('Could not change agent-specific parameters!');</script>";
+      }
+      break;
+      
     case "chunkreset";
       // reset chunk state and progress to zero
       $chunk=intval($_POST["chunk"]);
@@ -2229,6 +2239,15 @@ echo '</ul>
       echo "</form>";
       echo "</td></tr>";
       echo "<tr><td>Machine name:</td><td>".$erej["name"]."</td></tr>";
+
+      echo "<tr><td>Comment:</td><td>";
+      echo "<form action=\"$myself?a=agentcomment\" method=\"POST\">";
+      echo "<input type=\"hidden\" name=\"agent\" value=\"$agid\">";
+      echo "<input type=\"hidden\" name=\"return\" value=\"a=agentdetail&agent=$agid\">";
+      echo "<input type=\"text\" name=\"comment\" value=\"".$erej["comment"]."\" size=\"30\"> ";
+      echo "<input type=\"submit\" value=\"Set\"></form>";
+      echo "</td></tr>";
+
       echo "<tr><td>Operating system:</td><td>".$oses[$erej["os"]]."</td></tr>";
       echo "<tr><td>Access token:</td><td>".$erej["token"]."</td></tr>";
       echo "<tr><td>Machine ID:</td><td>".$erej["uid"]."</td></tr>";
@@ -2730,16 +2749,18 @@ echo '</ul>
       echo "Provide agent with valid voucher and this link:<br>";
       echo "<a href=\"server.php?a=update\">Download agent</a><br><br>";
       if (isset($_POST["newvoucher"])) {
-        mysqli_query_wrapper($dblink,"INSERT INTO regvouchers (voucher,time) VALUES ('".mysqli_real_escape_string($dblink,$_POST["newvoucher"])."',$cas)");
+        mysqli_query_wrapper($dblink,"INSERT INTO regvouchers (voucher,comment,time) VALUES ('".mysqli_real_escape_string($dblink,$_POST["newvoucher"])."','".mysqli_real_escape_string($dblink,$_POST["comment"])."',$cas)");
       }
-      $kver=mysqli_query_wrapper($dblink,"SELECT voucher,time FROM regvouchers");
+      $kver=mysqli_query_wrapper($dblink,"SELECT voucher,comment,time FROM regvouchers");
       if (mysqli_num_rows($kver)>0) {
         echo "Existing vouchers:<br>";
-        echo "<table class=\"styled\"><tr><td>Voucher</td><td>Issued</td><td>Action</td></tr>";
+        echo "<table class=\"styled\"><tr><td>Voucher</td><td>Issued</td><td>Comment</td><td>Action</td></tr>";
         while ($erej=mysqli_fetch_array($kver,MYSQLI_ASSOC)) {
           $id=$erej["voucher"];
+          $comment=$erej["comment"];
           echo "<tr><td>$id</td>";
           echo "<td>".date($config["timefmt"],$erej["time"])."</td>";
+          echo "<td>$comment</td>";
           echo "<td><form action=\"$myself?a=voucherdelete\" method=\"POST\" onSubmit=\"if (!confirm('Really delete this voucher?')) return false;\">";
           echo "<input type=\"hidden\" name=\"return\" value=\"a=deploy\">";
           echo "<input type=\"hidden\" name=\"voucher\" value=\"$id\">";
@@ -2748,9 +2769,10 @@ echo '</ul>
         echo "</table>Used vouchers are automaticaly deleted to prevent double spending.<br><br>";
       }
       echo "<form action=\"$myself?a=deploy\" method=\"POST\">";
-      echo "<table class=\"styled\"><tr><td>New voucher</td></tr>";
-      echo "<tr><td><input type=\"text\" name=\"newvoucher\" value=\"".generate_random(8)."\"></td></tr>";
-      echo "<tr><td><input type=\"submit\" value=\"Create\"></td></tr>";
+      echo "<table class=\"styled\"><tr><td colspan=2>New voucher</td></tr>";
+      echo "<tr><td>Voucher</td><td><input type=\"text\" name=\"newvoucher\" value=\"".generate_random(8)."\"></td></tr>";
+      echo "<tr><td>Comment (optional)</td><td><input type=\"text\" name=\"comment\" value=\"\"></td></tr>";
+      echo "<tr><td colspan=2><input type=\"submit\" value=\"Create\"></td></tr>";
       echo "</table></form>";
       break;
     

--- a/dbconfig.php
+++ b/dbconfig.php
@@ -6,6 +6,7 @@ $dbname="dbname";
 $dblink = @mysqli_connect($dbhost,$dbuser,$dbpass,$dbname) or die("Error " . mysqli_connect_error($dblink));
 $separator="\x01";
 $sess_name="auth";
+$exename="hashtopus.exe";
 
 $kv=mysqli_query($dblink,"SELECT * FROM config");
 $config=array();

--- a/hashtopus.sql
+++ b/hashtopus.sql
@@ -38,6 +38,7 @@ CREATE TABLE `agents` (
   `active` bit(1) NOT NULL DEFAULT b'1' COMMENT 'Flag if agent is active',
   `trusted` bit(1) NOT NULL DEFAULT b'1' COMMENT 'Is agent trusted for secret data?',
   `token` varchar(10) COLLATE latin1_bin NOT NULL COMMENT 'Generated access token',
+  `comment` varchar(250) COLLATE latin1_bin NOT NULL DEFAULT '' COMMENT 'Optional comment',
   `lastact` varchar(10) COLLATE latin1_bin NOT NULL DEFAULT '' COMMENT 'Last action',
   `lasttime` bigint(20) NOT NULL DEFAULT '0' COMMENT 'Last action time',
   `lastip` varchar(15) COLLATE latin1_bin NOT NULL DEFAULT '' COMMENT 'Last action IP',
@@ -258,6 +259,7 @@ DROP TABLE IF EXISTS `regvouchers`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `regvouchers` (
   `voucher` varchar(10) COLLATE latin1_bin NOT NULL COMMENT 'Registration vouchers',
+  `comment` varchar(250) COLLATE latin1_bin NOT NULL COMMENT 'Optional comment',
   `time` bigint(20) NOT NULL COMMENT 'Timestamp of creation',
   PRIMARY KEY (`voucher`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1 COLLATE=latin1_bin COMMENT='Tokens allowing agent registration';

--- a/server.php
+++ b/server.php
@@ -25,7 +25,6 @@ function mysqli_query_wrapper($dblink, $query) {
 
 set_time_limit(0);
 include("dbconfig.php");
-$exename="hashtopus.exe";
 
 $action=mysqli_real_escape_string($dblink,@$_GET["a"]);
 $token=mysqli_real_escape_string($dblink,@$_GET["token"]);
@@ -106,6 +105,14 @@ switch ($action) {
   case "update":
     // check if provided hash is the same as executable and send file contents if not
     $hash=$_GET["hash"];
+    if (!file_exists($exename)) {
+      if (! $hash) {
+        // initial deployment
+        header("Content-Type: text/plain");
+        echo "No agent software found on server! Try again later";
+      }
+      break;
+    }
     $htexe=file_get_contents($exename)."http".(isset($_SERVER['HTTPS']) ? "s" : "")."://".$_SERVER['HTTP_HOST'].$_SERVER['SCRIPT_NAME'];
     $myhash=md5($htexe);
     if ($hash!=$myhash) {

--- a/server.php
+++ b/server.php
@@ -37,11 +37,12 @@ switch ($action) {
   case "reg":
     // register at master server - user will be given a token
     $voucher=mysqli_real_escape_string($dblink,$_POST["voucher"]);
+    $failure = false;
     mysqli_query_wrapper($dblink,"START TRANSACTION");
     $kvery=mysqli_query_wrapper($dblink,"SELECT comment FROM regvouchers WHERE voucher='$voucher'");
     if (mysqli_num_rows($kvery)==1) {
       $erej=mysqli_fetch_array($kvery,MYSQLI_ASSOC);
-      $comment=$erej["comment"];
+      $comment=mysqli_real_escape_string($dblink,$erej["comment"]);
       mysqli_query_wrapper($dblink,"DELETE FROM regvouchers WHERE voucher='$voucher'");
       $cpu=intval($_POST["cpu"]);
       $gpu=mysqli_real_escape_string($dblink,$_POST["gpus"]);
@@ -68,11 +69,17 @@ switch ($action) {
         echo "reg_ok".$separator.$token;
       } else {
         echo "reg_nok".$separator."Could not register you to server.";
+        $failure = true;
       }
     } else {
       echo "reg_nok".$separator."Provided voucher does not exist.";
+      $failure = true;
     }
-    mysqli_query_wrapper($dblink,"COMMIT");
+    if ($failure) {
+      mysqli_query_wrapper($dblink,"ROLLBACK");
+    } else {
+      mysqli_query_wrapper($dblink,"COMMIT");
+    }
     break;
 
   case "log":

--- a/server.php
+++ b/server.php
@@ -38,8 +38,10 @@ switch ($action) {
     // register at master server - user will be given a token
     $voucher=mysqli_real_escape_string($dblink,$_POST["voucher"]);
     mysqli_query_wrapper($dblink,"START TRANSACTION");
-    $tc=mysqli_query_wrapper($dblink,"SELECT 1 FROM regvouchers WHERE voucher='$voucher'");
-    if (mysqli_num_rows($tc)==1) {
+    $kvery=mysqli_query_wrapper($dblink,"SELECT comment FROM regvouchers WHERE voucher='$voucher'");
+    if (mysqli_num_rows($kvery)==1) {
+      $erej=mysqli_fetch_array($kvery,MYSQLI_ASSOC);
+      $comment=$erej["comment"];
       mysqli_query_wrapper($dblink,"DELETE FROM regvouchers WHERE voucher='$voucher'");
       $cpu=intval($_POST["cpu"]);
       $gpu=mysqli_real_escape_string($dblink,$_POST["gpus"]);
@@ -62,7 +64,7 @@ switch ($action) {
       $token=generate_random(10);
       
       // save the new agent to the db or update existing one with the same hdd-serial
-      if (mysqli_query_wrapper($dblink,"INSERT INTO agents (name, uid, os, cputype, gpubrand, gpus, token) VALUES ('$name', '$uid', $os, $cpu, $brand,'$gpu','$token') ON DUPLICATE KEY UPDATE name='$name',os=$os,cputype=$cpu,gpubrand=$brand,gpus='$gpu',token='$token'")) {
+      if (mysqli_query_wrapper($dblink,"INSERT INTO agents (name, uid, os, cputype, gpubrand, gpus, token, comment) VALUES ('$name', '$uid', $os, $cpu, $brand,'$gpu','$token', '$comment') ON DUPLICATE KEY UPDATE name='$name',os=$os,cputype=$cpu,gpubrand=$brand,gpus='$gpu',token='$token',comment='$comment'")) {
         echo "reg_ok".$separator.$token;
       } else {
         echo "reg_nok".$separator."Could not register you to server.";


### PR DESCRIPTION
Added optional comment parameter for agent deploy to help identify agent after registration.
You can specify comment upon voucher issuing. After agent registered successfully with this voucher comment passed to agent profile and can be changed any time.

Feel free to approve or reject this request.

In order to upgrade SQL schema run this queries:

ALTER TABLE regvouchers ADD COLUMN `comment` varchar(250) COLLATE latin1_bin NOT NULL COMMENT 'Optional comment' AFTER `voucher`;
ALTER TABLE agents ADD COLUMN  `comment` varchar(250) COLLATE latin1_bin NOT NULL DEFAULT '' COMMENT 'Optional comment' AFTER `token`;

PS: I think it is good idea to supply each release with .sql files for schema migration
