### PR TITLE
Better hashtopus agent executable handling

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -2727,8 +2727,13 @@ echo '</ul>
       
     case "deploy":
       // manage registration vouchers
-      echo "Provide agent with valid voucher and this link:<br>";
-      echo "<a href=\"server.php?a=update\">Download agent</a><br><br>";
+      if (file_exists($exename)) {
+        echo "Provide agent with valid voucher and this link:<br>";
+        echo "<a href=\"server.php?a=update\">Download agent</a><br><br>";
+      } else {
+        echo "<p style='color:red'>There is no client executable file <b>$exename</b> in server root!<br>";
+        echo "Please upload $exename in order to deploy it to agents</p>";
+      }
       if (isset($_POST["newvoucher"])) {
         mysqli_query_wrapper($dblink,"INSERT INTO regvouchers (voucher,time) VALUES ('".mysqli_real_escape_string($dblink,$_POST["newvoucher"])."',$cas)");
       }

--- a/dbconfig.php
+++ b/dbconfig.php
@@ -6,6 +6,7 @@ $dbname="dbname";
 $dblink = @mysqli_connect($dbhost,$dbuser,$dbpass,$dbname) or die("Error " . mysqli_connect_error($dblink));
 $separator="\x01";
 $sess_name="auth";
+$exename="hashtopus.exe";
 
 $kv=mysqli_query($dblink,"SELECT * FROM config");
 $config=array();

--- a/server.php
+++ b/server.php
@@ -25,7 +25,6 @@ function mysqli_query_wrapper($dblink, $query) {
 
 set_time_limit(0);
 include("dbconfig.php");
-$exename="hashtopus.exe";
 
 $action=mysqli_real_escape_string($dblink,@$_GET["a"]);
 $token=mysqli_real_escape_string($dblink,@$_GET["token"]);
@@ -97,6 +96,14 @@ switch ($action) {
   case "update":
     // check if provided hash is the same as executable and send file contents if not
     $hash=$_GET["hash"];
+    if (!file_exists($exename)) {
+      if (! $hash) {
+        // initial deployment
+        header("Content-Type: text/plain");
+        echo "No agent software found on server! Try again later";
+      }
+      break;
+    }
     $htexe=file_get_contents($exename)."http".(isset($_SERVER['HTTPS']) ? "s" : "")."://".$_SERVER['HTTP_HOST'].$_SERVER['SCRIPT_NAME'];
     $myhash=md5($htexe);
     if ($hash!=$myhash) {


### PR DESCRIPTION
- Make executable name configurable with dbconfig.php
- Check if executable exists. If not then:
  *\* Show cautition message in admin console
  *\* Show error message on deploy url
